### PR TITLE
fix: set cookies based on refresh operation success

### DIFF
--- a/backend/auth/src/main/java/com/ernestas/auth/graphql/ResponseContextInterceptor.java
+++ b/backend/auth/src/main/java/com/ernestas/auth/graphql/ResponseContextInterceptor.java
@@ -2,6 +2,7 @@ package com.ernestas.auth.graphql;
 
 import java.util.Optional;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.graphql.server.WebGraphQlInterceptor;
 import org.springframework.graphql.server.WebGraphQlRequest;
 import org.springframework.graphql.server.WebGraphQlResponse;
@@ -17,11 +18,28 @@ class ResponseContextInterceptor implements WebGraphQlInterceptor {
     private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
     private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
+    private final String profile;
+    private final String domain;
+
     /**
-     * Intercepts GraphQL requests and, for operations containing "Refresh" in their name,
-     * adds access and refresh token cookies to the response headers.
+     * Constructs a ResponseContextInterceptor with the specified active Spring profile and domain.
      *
-     * <p>For non-"Refresh" operations, the request proceeds without modification.</p>
+     * @param profile the active Spring profile, defaults to "dev" if not set
+     * @param domain the domain for cookie configuration, defaults to "localhost" if not set
+     */
+    public ResponseContextInterceptor(
+            @Value("${spring.profiles.active:dev}") String profile,
+            @Value("${domain:localhost}") String domain) {
+        this.profile = profile;
+        this.domain = domain;
+    }
+
+    /**
+     * Intercepts GraphQL requests and, for successful operations containing "Refresh" in their name,
+     * adds access and refresh token cookies to the response headers with proper security attributes.
+     *
+     * <p>For non-"Refresh" operations, the request proceeds without modification.
+     * Cookies are only set if the operation succeeds and both tokens are present in the context.</p>
      *
      * @param request the incoming GraphQL web request
      * @param chain the interceptor chain
@@ -36,14 +54,30 @@ class ResponseContextInterceptor implements WebGraphQlInterceptor {
         }
 
         return chain.next(request).doOnNext((response) -> {
-            String accessCookieString = response.getExecutionInput().getGraphQLContext().get(ACCESS_TOKEN_COOKIE_NAME);
-            ResponseCookie accessCookie = ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessCookieString).build();
-            response.getResponseHeaders().add(HttpHeaders.SET_COOKIE, accessCookie.toString());
+            // Only set cookies if the operation succeeded (no errors in the response)
+            if (response.getErrors().isEmpty()) {
+                String accessCookieString = response.getExecutionInput().getGraphQLContext().get(ACCESS_TOKEN_COOKIE_NAME);
+                String refreshCookieString = response.getExecutionInput().getGraphQLContext().get(REFRESH_TOKEN_COOKIE_NAME);
 
-            String refreshCookieString = response.getExecutionInput().getGraphQLContext()
-                    .get(REFRESH_TOKEN_COOKIE_NAME);
-            ResponseCookie refreshCookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshCookieString).build();
-            response.getResponseHeaders().add(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+                // Only set cookies if both tokens are present
+                if (accessCookieString != null && refreshCookieString != null) {
+                    ResponseCookie accessCookie = ResponseCookie.from(ACCESS_TOKEN_COOKIE_NAME, accessCookieString)
+                            .path("/")
+                            .httpOnly(true)
+                            .secure(profile.equals("prod"))
+                            .domain(domain)
+                            .build();
+                    response.getResponseHeaders().add(HttpHeaders.SET_COOKIE, accessCookie.toString());
+
+                    ResponseCookie refreshCookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, refreshCookieString)
+                            .path("/")
+                            .httpOnly(true)
+                            .secure(profile.equals("prod"))
+                            .domain(domain)
+                            .build();
+                    response.getResponseHeaders().add(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+                }
+            }
         });
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cookie handling to ensure cookies are only set when the operation is a refresh, there are no errors, and both tokens are present. Enhanced security attributes for cookies, including HttpOnly, path, domain, and conditional secure flag based on environment.

* **Tests**
  * Added and updated tests to verify cookies are not set when errors are present or tokens are missing, and to validate new cookie attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->